### PR TITLE
CRDCDH-298 getUser endpoint

### DIFF
--- a/resources/graphql/authorization.graphql
+++ b/resources/graphql/authorization.graphql
@@ -60,6 +60,7 @@ type Query {
 
     "Admin and Org Owner only operations, Org Owner only see users within same organization"
     listUsers: [User]
+    getUser(userID: ID!): User
 }
 
 type Mutation {

--- a/routers/graphql-router.js
+++ b/routers/graphql-router.js
@@ -16,6 +16,7 @@ dbConnector.connect().then(() => {
     const dataInterface = new User(userCollection, logCollection);
     root = {
         getMyUser : dataInterface.getMyUser.bind(dataInterface),
+        getUser : dataInterface.getUser.bind(dataInterface),
         updateMyUser : dataInterface.updateMyUser.bind(dataInterface),
     };
 });


### PR DESCRIPTION
### Overview

This PR supports CRDCDH-298 to add a `getUser` (by `_id`) endpoint. 

Pending submodule update.