### PR TITLE
CRDCDH-274 `editUser` and `listOrganizations`

### DIFF
--- a/routers/graphql-router.js
+++ b/routers/graphql-router.js
@@ -2,9 +2,10 @@ const {buildSchema} = require('graphql');
 const {createHandler} = require("graphql-http/lib/use/express");
 const config = require("../config");
 const {MongoDBCollection} = require("../crdc-datahub-database-drivers/mongodb-collection");
-const {DATABASE_NAME, USER_COLLECTION, LOG_COLLECTION} = require("../crdc-datahub-database-drivers/database-constants");
+const {DATABASE_NAME, USER_COLLECTION, LOG_COLLECTION, ORGANIZATION_COLLECTION} = require("../crdc-datahub-database-drivers/database-constants");
 const {DatabaseConnector} = require("../crdc-datahub-database-drivers/database-connector");
 const {User} = require("../crdc-datahub-database-drivers/services/user")
+const {Organization} = require("../crdc-datahub-database-drivers/services/organization")
 
 const schema = buildSchema(require("fs").readFileSync("resources/graphql/authorization.graphql", "utf8"));
 const dbConnector = new DatabaseConnector(config.mongo_db_connection_string);
@@ -13,12 +14,16 @@ let root;
 dbConnector.connect().then(() => {
     const userCollection = new MongoDBCollection(dbConnector.client, DATABASE_NAME, USER_COLLECTION);
     const logCollection = new MongoDBCollection(dbConnector.client, DATABASE_NAME, LOG_COLLECTION);
-    const dataInterface = new User(userCollection, logCollection);
+    const organizationCollection = new MongoDBCollection(dbConnector.client, DATABASE_NAME, ORGANIZATION_COLLECTION);
+    const organizationService = new Organization(organizationCollection);
+    const dataInterface = new User(userCollection, logCollection, organizationService);
     root = {
         getMyUser : dataInterface.getMyUser.bind(dataInterface),
         getUser : dataInterface.getUser.bind(dataInterface),
         updateMyUser : dataInterface.updateMyUser.bind(dataInterface),
         listUsers : dataInterface.listUsers.bind(dataInterface),
+        editUser : dataInterface.editUser.bind(dataInterface),
+        listOrganizations : dataInterface.listOrganizations.bind(dataInterface),
     };
 });
 module.exports = (req, res) => {


### PR DESCRIPTION
### Overview

This PR enables the `editUser` and `listOrganizations` AuthZ API endpoints based on the database-drivers PR https://github.com/CBIIT/crdc-datahub-database-drivers/pull/19

The `organization` collection needs to have the default orgs added. You can import this JSON object into the `organization` collection or create the entries manually. [CRDC-Organization-Full.txt](https://github.com/CBIIT/crdc-datahub-authz/files/12488478/CRDC-Organization-Full.txt)


> **Note**: This is based on the CRDCDH-273 branch