### PR TITLE
CRDCDH-352 Update listOrganizations implementation

### DIFF
--- a/routers/graphql-router.js
+++ b/routers/graphql-router.js
@@ -6,8 +6,6 @@ const {DATABASE_NAME, USER_COLLECTION, LOG_COLLECTION, ORGANIZATION_COLLECTION} 
 const {DatabaseConnector} = require("../crdc-datahub-database-drivers/database-connector");
 const {User} = require("../crdc-datahub-database-drivers/services/user")
 const {Organization} = require("../crdc-datahub-database-drivers/services/organization")
-const {ERROR} = require("../crdc-datahub-database-drivers/constants/error-constants");
-const {USER} = require("../crdc-datahub-database-drivers/constants/user-constants");
 
 const schema = buildSchema(require("fs").readFileSync("resources/graphql/authorization.graphql", "utf8"));
 const dbConnector = new DatabaseConnector(config.mongo_db_connection_string);
@@ -17,7 +15,7 @@ dbConnector.connect().then(() => {
     const userCollection = new MongoDBCollection(dbConnector.client, DATABASE_NAME, USER_COLLECTION);
     const logCollection = new MongoDBCollection(dbConnector.client, DATABASE_NAME, LOG_COLLECTION);
     const organizationCollection = new MongoDBCollection(dbConnector.client, DATABASE_NAME, ORGANIZATION_COLLECTION);
-    const organizationService = new Organization(organizationCollection);
+    const organizationInterface = new Organization(organizationCollection);
     const dataInterface = new User(userCollection, logCollection, organizationCollection);
     root = {
         getMyUser : dataInterface.getMyUser.bind(dataInterface),
@@ -25,24 +23,7 @@ dbConnector.connect().then(() => {
         updateMyUser : dataInterface.updateMyUser.bind(dataInterface),
         listUsers : dataInterface.listUsers.bind(dataInterface),
         editUser : dataInterface.editUser.bind(dataInterface),
-        listOrganizations: (params, context) => {
-            if (!context?.userInfo?.email || !context?.userInfo?.IDP) {
-                throw new Error(ERROR.NOT_LOGGED_IN)
-            }
-            if (context?.userInfo?.role !== USER.ROLES.ADMIN && context?.userInfo.role !== USER.ROLES.ORG_OWNER) {
-                throw new Error(ERROR.INVALID_ROLE);
-            }
-            if (context.userInfo.role === USER.ROLES.ORG_OWNER && !context?.userInfo?.organization?.orgID) {
-                throw new Error(ERROR.NO_ORG_ASSIGNED);
-            }
-
-            const filters = {};
-            if (context?.userInfo?.role === USER.ROLES.ORG_OWNER) {
-                filters["_id"] = context?.userInfo?.organization?.orgID;
-            }
-
-            return organizationService.listOrganizations(filters);
-        },
+        listOrganizations : organizationInterface.listOrganizationsAPI.bind(organizationInterface),
     };
 });
 

--- a/routers/graphql-router.js
+++ b/routers/graphql-router.js
@@ -6,6 +6,9 @@ const {DATABASE_NAME, USER_COLLECTION, LOG_COLLECTION, ORGANIZATION_COLLECTION} 
 const {DatabaseConnector} = require("../crdc-datahub-database-drivers/database-connector");
 const {User} = require("../crdc-datahub-database-drivers/services/user")
 const {Organization} = require("../crdc-datahub-database-drivers/services/organization")
+const {ERROR} = require("../crdc-datahub-database-drivers/constants/error-constants");
+const {USER} = require("../crdc-datahub-database-drivers/constants/user-constants");
+const {ORGANIZATION} = require("../crdc-datahub-database-drivers/constants/organization-constants");
 
 const schema = buildSchema(require("fs").readFileSync("resources/graphql/authorization.graphql", "utf8"));
 const dbConnector = new DatabaseConnector(config.mongo_db_connection_string);
@@ -16,16 +19,34 @@ dbConnector.connect().then(() => {
     const logCollection = new MongoDBCollection(dbConnector.client, DATABASE_NAME, LOG_COLLECTION);
     const organizationCollection = new MongoDBCollection(dbConnector.client, DATABASE_NAME, ORGANIZATION_COLLECTION);
     const organizationService = new Organization(organizationCollection);
-    const dataInterface = new User(userCollection, logCollection, organizationService);
+    const dataInterface = new User(userCollection, logCollection, organizationCollection);
     root = {
         getMyUser : dataInterface.getMyUser.bind(dataInterface),
         getUser : dataInterface.getUser.bind(dataInterface),
         updateMyUser : dataInterface.updateMyUser.bind(dataInterface),
         listUsers : dataInterface.listUsers.bind(dataInterface),
         editUser : dataInterface.editUser.bind(dataInterface),
-        listOrganizations : dataInterface.listOrganizations.bind(dataInterface),
+        listOrganizations: (params, context) => {
+            if (!context?.userInfo?.email || !context?.userInfo?.IDP) {
+                throw new Error(ERROR.NOT_LOGGED_IN)
+            }
+            if (context?.userInfo?.role !== USER.ROLES.ADMIN && context?.userInfo.role !== USER.ROLES.ORG_OWNER) {
+                throw new Error(ERROR.INVALID_ROLE);
+            }
+            if (context.userInfo.role === USER.ROLES.ORG_OWNER && !context?.userInfo?.organization?.orgID) {
+                throw new Error(ERROR.NO_ORG_ASSIGNED);
+            }
+
+            const filters = { status: ORGANIZATION.STATUSES.ACTIVE };
+            if (context?.userInfo?.role === USER.ROLES.ORG_OWNER) {
+                filters["_id"] = context?.userInfo?.organization?.orgID;
+            }
+
+            return organizationService.listOrganizations(filters);
+        },
     };
 });
+
 module.exports = (req, res) => {
     createHandler({
         schema: schema,

--- a/routers/graphql-router.js
+++ b/routers/graphql-router.js
@@ -8,7 +8,6 @@ const {User} = require("../crdc-datahub-database-drivers/services/user")
 const {Organization} = require("../crdc-datahub-database-drivers/services/organization")
 const {ERROR} = require("../crdc-datahub-database-drivers/constants/error-constants");
 const {USER} = require("../crdc-datahub-database-drivers/constants/user-constants");
-const {ORGANIZATION} = require("../crdc-datahub-database-drivers/constants/organization-constants");
 
 const schema = buildSchema(require("fs").readFileSync("resources/graphql/authorization.graphql", "utf8"));
 const dbConnector = new DatabaseConnector(config.mongo_db_connection_string);
@@ -37,7 +36,7 @@ dbConnector.connect().then(() => {
                 throw new Error(ERROR.NO_ORG_ASSIGNED);
             }
 
-            const filters = { status: ORGANIZATION.STATUSES.ACTIVE };
+            const filters = {};
             if (context?.userInfo?.role === USER.ROLES.ORG_OWNER) {
                 filters["_id"] = context?.userInfo?.organization?.orgID;
             }


### PR DESCRIPTION
### Overview

This PR provides supporting changes to CRDC-DH AuthZ service for PR #30 and [CRDCDH-352](https://tracker.nci.nih.gov/browse/CRDCDH-352).

Specifics:

* Replaces the `OrgInfo` type wrapper for `listOrganizations`
* Moves the `listOrganizations` implementation out of the User Service

Notes:

- This endpoint intentionally returns inactive and active organizations. Filtering is done on the FE depending on the context

### Related PRs

Requires driver update – https://github.com/CBIIT/crdc-datahub-database-drivers/pull/33

